### PR TITLE
internal/ethapi: add withdrawals to full block

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1241,6 +1241,7 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *param
 		}
 		fields["transactions"] = transactions
 		// inclTx also expands withdrawals
+		// TODO @MariusVanDerWijden: add a second flag similar to inclTx to enable withdrawals
 		fields["withdrawals"] = block.Withdrawals()
 	}
 	uncles := block.Uncles()

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1240,6 +1240,8 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *param
 			}
 		}
 		fields["transactions"] = transactions
+		// inclTx also expands withdrawals
+		fields["withdrawals"] = block.Withdrawals()
 	}
 	uncles := block.Uncles()
 	uncleHashes := make([]common.Hash, len(uncles))


### PR DESCRIPTION
In the future we might want to add a flag similar to `inclTx` like `inclWithdrawals` to include one or the other. 
It's a bit overkill now imo