### PR TITLE
validateInstructions

### DIFF
--- a/core/vm/eof.go
+++ b/core/vm/eof.go
@@ -238,8 +238,9 @@ func validateInstructions(code []byte, header *EOF1Header, jumpTable *JumpTable)
 		case jumpTable[opcode].undefined:
 			return fmt.Errorf("%v: %v", ErrEOF1UndefinedInstruction, opcode)
 		case opcode >= PUSH1 && opcode <= PUSH32:
+			
 			i += int(opcode) - int(PUSH1) + 2
-			continue // todo make sure this actually continues
+			
 		case opcode == RJUMP || opcode == RJUMPI:
 			var arg int16
 			// Read immediate argument.


### PR DESCRIPTION
Switch statements when matching a case will yield control back, in this case to the top of the loop -- break / continue not needed here