### PR TITLE
eth/catalyst/api.go: Return InvalidParams error if cancun fields in NewPayloadV2.

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -456,6 +456,14 @@ func (api *ConsensusAPI) NewPayloadV2(params engine.ExecutableData) (engine.Payl
 		if params.Withdrawals == nil {
 			return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("nil withdrawals post-shanghai"))
 		}
+		if !api.eth.BlockChain().Config().IsCancun(new(big.Int).SetUint64(params.Number), params.Timestamp) {
+			if params.ExcessBlobGas != nil {
+				return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("non-nil excessBlobGas pre-cancun"))
+			}
+			if params.BlobGasUsed != nil {
+				return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("non-nil blobGasUsed pre-cancun"))
+			}
+		}
 	} else if params.Withdrawals != nil {
 		return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("non-nil withdrawals pre-shanghai"))
 	}


### PR DESCRIPTION
This fixes a mismatch in NewPayloadV2 of the Shanghai spec: https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#specification

> Client software MUST return -32602: Invalid params error if the wrong version of the structure is used in the method call.

For example, when we have the case where excessBlobGas is non-nil at Shanghai and used within the NewPayloadV2 method.

All current `pyspec` tests pass with this :D