### PR TITLE
core/types: update beacon root json tag to match rpc

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -92,7 +92,7 @@ type Header struct {
 	ExcessBlobGas *uint64 `json:"excessBlobGas" rlp:"optional"`
 
 	// BeaconRoot was added by EIP-4788 and is ignored in legacy headers.
-	BeaconRoot *common.Hash `json:"beaconRoot" rlp:"optional"`
+	BeaconRoot *common.Hash `json:"parentBeaconBlockRoot" rlp:"optional"`
 }
 
 // field type overrides for gencodec

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -35,7 +35,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 		WithdrawalsHash *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
 		BlobGasUsed     *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
 		ExcessBlobGas   *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
-		BeaconRoot      *common.Hash    `json:"beaconRoot" rlp:"optional"`
+		BeaconRoot      *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
 		Hash            common.Hash     `json:"hash"`
 	}
 	var enc Header
@@ -85,7 +85,7 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 		WithdrawalsHash *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
 		BlobGasUsed     *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
 		ExcessBlobGas   *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
-		BeaconRoot      *common.Hash    `json:"beaconRoot" rlp:"optional"`
+		BeaconRoot      *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
 	}
 	var dec Header
 	if err := json.Unmarshal(input, &dec); err != nil {


### PR DESCRIPTION
Found while developing the hive simulator, I'm using this struct to parse the blocks using `ethclient` and it was not able to parse the beacon root because the field is named `parentBeaconBlockRoot` in the RPC response, so it was always `nil` when calculating the hash.