### PR TITLE
cmd/evm: add requests/deposits to evm tool

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -67,7 +67,7 @@ type ExecutionResult struct {
 	CurrentExcessBlobGas *math.HexOrDecimal64  `json:"currentExcessBlobGas,omitempty"`
 	CurrentBlobGasUsed   *math.HexOrDecimal64  `json:"blobGasUsed,omitempty"`
 	RequestsRoot         *common.Hash          `json:"requestsRoot,omitempty"`
-	Deposits             *types.Deposits       `json:"deposits,omitempty"`
+	DepositRequests      *types.Deposits       `json:"depositRequests,omitempty"`
 }
 
 type ommer struct {
@@ -385,7 +385,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		execRs.RequestsRoot = &h
 		// Get the deposits from the requests
 		deposits := requests.Deposits()
-		execRs.Deposits = &deposits
+		execRs.DepositRequests = &deposits
 	}
 	// Re-create statedb instance with new root upon the updated database
 	// for accessing latest states.

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -66,6 +66,8 @@ type ExecutionResult struct {
 	WithdrawalsRoot      *common.Hash          `json:"withdrawalsRoot,omitempty"`
 	CurrentExcessBlobGas *math.HexOrDecimal64  `json:"currentExcessBlobGas,omitempty"`
 	CurrentBlobGasUsed   *math.HexOrDecimal64  `json:"blobGasUsed,omitempty"`
+	RequestsRoot         *common.Hash          `json:"requestsRoot,omitempty"`
+	Deposits             *types.Deposits       `json:"deposits,omitempty"`
 }
 
 type ommer struct {
@@ -367,6 +369,23 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 	if vmContext.BlobBaseFee != nil {
 		execRs.CurrentExcessBlobGas = (*math.HexOrDecimal64)(&excessBlobGas)
 		execRs.CurrentBlobGasUsed = (*math.HexOrDecimal64)(&blobGasUsed)
+	}
+	if chainConfig.IsPrague(vmContext.BlockNumber, vmContext.Time) {
+		// Parse the requests from the logs
+		var allLogs []*types.Log
+		for _, receipt := range receipts {
+			allLogs = append(allLogs, receipt.Logs...)
+		}
+		requests, err := core.ParseDepositLogs(allLogs)
+		if err != nil {
+			return nil, nil, nil, NewError(ErrorEVM, fmt.Errorf("could not parse requests logs: %v", err))
+		}
+		// Calculate the requests root
+		h := types.DeriveSha(requests, trie.NewStackTrie(nil))
+		execRs.RequestsRoot = &h
+		// Get the deposits from the requests
+		deposits := requests.Deposits()
+		execRs.Deposits = &deposits
 	}
 	// Re-create statedb instance with new root upon the updated database
 	// for accessing latest states.

--- a/core/types/request.go
+++ b/core/types/request.go
@@ -64,6 +64,17 @@ func (s Requests) EncodeIndex(i int, w *bytes.Buffer) {
 	rlp.Encode(w, s[i])
 }
 
+// Retrieve deposits from a requests list.
+func (s Requests) Deposits() Deposits {
+	deposits := make(Deposits, 0, len(s))
+	for _, req := range s {
+		if req.Type() == DepositRequestType {
+			deposits = append(deposits, req.inner.(*Deposit))
+		}
+	}
+	return deposits
+}
+
 type RequestData interface {
 	requestType() byte
 	encode(*bytes.Buffer) error

--- a/core/types/request.go
+++ b/core/types/request.go
@@ -61,7 +61,7 @@ func (s Requests) Len() int { return len(s) }
 
 // EncodeIndex encodes the i'th request to s.
 func (s Requests) EncodeIndex(i int, w *bytes.Buffer) {
-	rlp.Encode(w, s[i])
+	s[i].encode(w)
 }
 
 // Retrieve deposits from a requests list.


### PR DESCRIPTION
Adds requests root calculation and returns the deposits in the `evm t8n` command.

Currently there seems to be a behavior that the trie root is calculated with each element as:
```
rlp(DEPOSIT_REQUEST_TYPE + rlp([pubkey, ...])
```
instead of:
```
DEPOSIT_REQUEST_TYPE + rlp([pubkey, ...]
```
but I'm not sure if this is because of the code I added to cmd/evm/internal/t8ntool/execution.go, or something in the `Requests` type methods.