### PR TITLE
core: Add requests hash to genesis if Prague

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -475,6 +475,9 @@ func (g *Genesis) ToBlock() *types.Block {
 				head.BlobGasUsed = new(uint64)
 			}
 		}
+		if conf.IsPrague(num, g.Timestamp) {
+			head.RequestsHash = &types.EmptyRequestsHash
+		}
 	}
 	return types.NewBlock(head, nil, nil, nil, trie.NewStackTrie(nil)).WithWithdrawals(withdrawals)
 }


### PR DESCRIPTION
Adds requests hash to the genesis block generation to be able to parse `execution-spec-tests` fixtures.