### PR TITLE
fix: history serve floor

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -293,7 +293,7 @@ func ProcessBlockHashHistory(statedb *state.StateDB, header *types.Header, chain
 	if chainConfig.IsPrague(parent.Number, parent.Time) || prevNumber == 0 {
 		return
 	}
-	var low uint64
+	low := uint64(1) 
 	if number > params.HistoryServeWindow {
 		low = number - params.HistoryServeWindow
 	}


### PR DESCRIPTION
## Description

[EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) specifies that the hash for the genesis block should not be stored. Fix the floor value in case the Prague transition number is lte than history serve window.
```
def process_block_hash_history(block: Block, state: State):
    if block.timestamp >= FORK_TIMESTAMP:
        state.insert_slot(HISTORY_STORAGE_ADDRESS, (block.number-1) % HISTORY_SERVE_WINDOW , block.parent.hash)

    # If this is the fork block, add the parent's direct `HISTORY_SERVE_WINDOW - 1` ancestors as well
    if block.parent.timestamp < FORK_TIMESTAMP:
        ancestor = block.parent
        for i in range(HISTORY_SERVE_WINDOW - 1):
            # stop at genesis block
            if ancestor.number == 0:
                break

            ancestor = ancestor.parent
            state.insert_slot(HISTORY_STORAGE_ADDRESS, ancestor.number % HISTORY_SERVE_WINDOW, ancestor.hash)
```