### PR TITLE
fix: blockhash opcode gas cost

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -40,6 +40,7 @@ var activators = map[int]func(*JumpTable){
 	1884: enable1884,
 	1344: enable1344,
 	1153: enable1153,
+	2935: enable2935,
 	4762: enable4762,
 }
 
@@ -155,6 +156,12 @@ func enable2929(jt *JumpTable) {
 	// factor here
 	jt[SELFDESTRUCT].constantGas = params.SelfdestructGasEIP150
 	jt[SELFDESTRUCT].dynamicGas = gasSelfdestructEIP2929
+}
+
+// enable2935 enables "EIP-2935: Serve historical block hashes from state"
+// - Additionally charge the corresponding warm or cold SLOAD costs for BLOCKHASH
+func enable2935(jt *JumpTable) {
+	jt[BLOCKHASH].dynamicGas = gasSLoadEIP2929
 }
 
 // enable3529 enabled "EIP-3529: Reduction in refunds":

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -17,6 +17,7 @@
 package vm
 
 import (
+	"encoding/binary"
 	"math"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -447,7 +448,9 @@ func opBlockhash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) (
 		lower = upper - historySize
 	}
 	if num64 >= lower && num64 < upper {
-		num.SetBytes(interpreter.evm.Context.GetHash(num64).Bytes())
+		var key common.Hash
+		binary.BigEndian.PutUint64(key[24:], num64 % params.HistoryServeWindow)
+		num.SetBytes(interpreter.evm.StateDB.GetState(params.HistoryStorageAddress, key).Bytes())
 	} else {
 		num.Clear()
 	}

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -91,7 +91,7 @@ func newVerkleInstructionSet() JumpTable {
 func newPraugeInstructionSet() JumpTable {
 	instructionSet := newCancunInstructionSet()
 	enable3074(&instructionSet) // EIP-3074 AUTH & AUTHCALL
-	enable2935(&instructionSet)
+	enable2935(&instructionSet) // EIP-2935 Serve historical block hashes from state
 	return validate(instructionSet)
 }
 

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -91,6 +91,7 @@ func newVerkleInstructionSet() JumpTable {
 func newPraugeInstructionSet() JumpTable {
 	instructionSet := newCancunInstructionSet()
 	enable3074(&instructionSet) // EIP-3074 AUTH & AUTHCALL
+	enable2935(&instructionSet)
 	return validate(instructionSet)
 }
 
@@ -498,7 +499,7 @@ func newFrontierInstructionSet() JumpTable {
 		},
 		BLOCKHASH: {
 			execute:     opBlockhash,
-			constantGas: GasExtStep + params.SloadGasFrontier,
+			constantGas: GasExtStep,
 			minStack:    minStack(1, 1),
 			maxStack:    maxStack(1, 1),
 		},

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -498,7 +498,7 @@ func newFrontierInstructionSet() JumpTable {
 		},
 		BLOCKHASH: {
 			execute:     opBlockhash,
-			constantGas: GasExtStep,
+			constantGas: GasExtStep + params.SloadGasFrontier,
 			minStack:    minStack(1, 1),
 			maxStack:    maxStack(1, 1),
 		},


### PR DESCRIPTION
## Description

https://github.com/lightclient/go-ethereum/commit/9c7ec8561b0815a6524d2b74a7686e6a9146834a implements [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) but does not adjust gas costs for the `BLOCKHASH` opcode. Fix that by adding static gas cost of an `SLOAD` and actually loading block hash from storage.