### PR TITLE
core/types: fix withdrawal_request json tag

### DIFF
--- a/core/types/gen_withdrawal_request_json.go
+++ b/core/types/gen_withdrawal_request_json.go
@@ -15,7 +15,7 @@ var _ = (*withdrawalRequestMarshaling)(nil)
 func (w WithdrawalRequest) MarshalJSON() ([]byte, error) {
 	type WithdrawalRequest struct {
 		Source    common.Address `json:"sourceAddress"`
-		PublicKey [48]byte       `json:"validatorPublicKey"`
+		PublicKey [48]byte       `json:"validatorPubkey"`
 		Amount    hexutil.Uint64 `json:"amount"`
 	}
 	var enc WithdrawalRequest
@@ -29,7 +29,7 @@ func (w WithdrawalRequest) MarshalJSON() ([]byte, error) {
 func (w *WithdrawalRequest) UnmarshalJSON(input []byte) error {
 	type WithdrawalRequest struct {
 		Source    *common.Address `json:"sourceAddress"`
-		PublicKey *[48]byte       `json:"validatorPublicKey"`
+		PublicKey *[48]byte       `json:"validatorPubkey"`
 		Amount    *hexutil.Uint64 `json:"amount"`
 	}
 	var dec WithdrawalRequest

--- a/core/types/withdrawal_request.go
+++ b/core/types/withdrawal_request.go
@@ -30,7 +30,7 @@ import (
 // the validator associated with the public key for amount.
 type WithdrawalRequest struct {
 	Source    common.Address `json:"sourceAddress"`
-	PublicKey [48]byte       `json:"validatorPublicKey"`
+	PublicKey [48]byte       `json:"validatorPubkey"`
 	Amount    uint64         `json:"amount"`
 }
 


### PR DESCRIPTION
Fix public key field in the `WithdrawalRequest` type to match the changes specified here: https://github.com/ethereum/execution-apis/pull/549